### PR TITLE
Remove `safe` checking from clients

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -7,12 +7,6 @@ use Psr\SimpleCache\InvalidArgumentException;
 
 /**
  * Base cache implementation that standardizes calls to cache clients
- *
- * @uses CacheInterface
- * @package
- * @version $id$
- * @author Kevin Boyd <beryllium@beryllium.ca>
- * @license See LICENSE.md
  */
 class Cache implements CacheInterface
 {

--- a/src/Client/ApcuClient.php
+++ b/src/Client/ApcuClient.php
@@ -10,11 +10,8 @@ use Psr\SimpleCache\CacheInterface;
  */
 class ApcuClient implements CacheInterface
 {
-    private $safe;
-
     public function __construct()
     {
-        $this->safe = \extension_loaded('apcu');
     }
 
     /**
@@ -27,10 +24,6 @@ class ApcuClient implements CacheInterface
      */
     public function get($key, $default = null)
     {
-        if (!$this->safe) {
-            return false;
-        }
-
         return apcu_fetch($key) ?? $default;
     }
 
@@ -44,10 +37,6 @@ class ApcuClient implements CacheInterface
      */
     public function set($key, $value, $ttl = null): bool
     {
-        if (!$this->safe) {
-            return false;
-        }
-
         return apcu_store($key, $value, $ttl ?? 0);
     }
 
@@ -59,10 +48,6 @@ class ApcuClient implements CacheInterface
      */
     public function delete($key): bool
     {
-        if (!$this->safe) {
-            return false;
-        }
-
         return apcu_delete($key);
     }
 
@@ -73,10 +58,6 @@ class ApcuClient implements CacheInterface
      */
     public function clear(): bool
     {
-        if (!$this->safe) {
-            return false;
-        }
-
         return apcu_clear_cache();
     }
 
@@ -94,10 +75,6 @@ class ApcuClient implements CacheInterface
      */
     public function getMultiple($keys, $default = null)
     {
-        if (!$this->safe) {
-            return false;
-        }
-
         if (!\is_array($keys) || !$keys instanceof \Traversable) {
             throw new InvalidArgumentException('Unable to getMultiple using non-array/non-Traversable keys');
         }
@@ -121,10 +98,6 @@ class ApcuClient implements CacheInterface
      */
     public function setMultiple($values, $ttl = null): bool
     {
-        if (!$this->safe) {
-            return false;
-        }
-
         if (!\is_array($values) || !$values instanceof \Traversable) {
             throw new InvalidArgumentException('Unable to setMultiple using non-array/non-Traversable values');
         }
@@ -145,10 +118,6 @@ class ApcuClient implements CacheInterface
      */
     public function deleteMultiple($keys): bool
     {
-        if (!$this->safe) {
-            return false;
-        }
-
         if (!\is_array($keys) || !$keys instanceof \Traversable) {
             throw new InvalidArgumentException('Unable to deleteMultiple using non-array/non-Traversable keys');
         }
@@ -173,10 +142,6 @@ class ApcuClient implements CacheInterface
      */
     public function has($key): bool
     {
-        if (!$this->safe) {
-            return false;
-        }
-
         return apcu_exists($key);
     }
 }

--- a/src/Client/ApcuClient.php
+++ b/src/Client/ApcuClient.php
@@ -10,10 +10,6 @@ use Psr\SimpleCache\CacheInterface;
  */
 class ApcuClient implements CacheInterface
 {
-    public function __construct()
-    {
-    }
-
     /**
      * Retrieve the value corresponding to a provided key
      *

--- a/src/Client/FilecacheClient.php
+++ b/src/Client/FilecacheClient.php
@@ -20,9 +20,9 @@ class FilecacheClient implements CacheInterface
     private $path;
 
     /**
-     * @param string|null $path
+     * @param string $path
      */
-    public function __construct($path)
+    public function __construct(string $path)
     {
         $path = rtrim($path, DIRECTORY_SEPARATOR);
 
@@ -114,7 +114,7 @@ class FilecacheClient implements CacheInterface
      * @param string $key
      * @return string
      */
-    private function getFilename($key)
+    protected function getFilename(string $key): string
     {
         return $this->path . DIRECTORY_SEPARATOR . md5($key) . '_file.cache';
     }

--- a/src/Client/FilecacheClient.php
+++ b/src/Client/FilecacheClient.php
@@ -155,7 +155,7 @@ class FilecacheClient implements CacheInterface
         return serialize($data);
     }
 
-    protected function unserialize($data, ?$options = null)
+    protected function unserialize($data, $options = null)
     {
         return unserialize($data, $options);
     }

--- a/src/Client/FilecacheClient.php
+++ b/src/Client/FilecacheClient.php
@@ -2,6 +2,7 @@
 
 namespace Beryllium\Cache\Client;
 
+use Beryllium\Cache\Exception\InvalidPathException;
 use Beryllium\Cache\Statistics\Tracker\StatisticsTrackerInterface;
 use Psr\SimpleCache\CacheInterface;
 
@@ -30,15 +31,15 @@ class FilecacheClient implements CacheInterface
         $path = rtrim($path, DIRECTORY_SEPARATOR);
 
         if (empty($path)) {
-            return;
+            throw new InvalidPathException('Path was not provided');
         }
 
         if (!is_dir($path) && !mkdir($path) && !is_dir($path)) {
-            return;
+            throw new InvalidPathException('Provided path directory does not exist and/or could not be created');
         }
 
         if (!is_writable($path)) {
-            return;
+            throw new InvalidPathException('Provided path is not a writable directory');
         }
 
         $this->path = $path;
@@ -121,14 +122,6 @@ class FilecacheClient implements CacheInterface
     }
 
     /**
-     * @return bool
-     */
-    public function isSafe()
-    {
-        return $this->path !== null;
-    }
-
-    /**
      * @param StatisticsTrackerInterface $statisticsTracker
      */
     public function setStatisticsTracker(StatisticsTrackerInterface $statisticsTracker)
@@ -190,14 +183,10 @@ class FilecacheClient implements CacheInterface
      */
     public function has($key)
     {
-        if (empty($key) || !$this->isSafe()) {
+        if (empty($key)) {
             return false;
         }
 
-        if (!file_exists($this->getFilename($key))) {
-            return false;
-        }
-
-        return true;
+        return file_exists($this->getFilename($key));
     }
 }

--- a/src/Client/FilecacheClient.php
+++ b/src/Client/FilecacheClient.php
@@ -25,7 +25,7 @@ class FilecacheClient implements CacheInterface
             throw new InvalidPathException('Path was not provided');
         }
 
-        if (!is_dir($path) && !mkdir($path) && !is_dir($path)) {
+        if (!is_dir($path) && !@mkdir($path) && !is_dir($path)) {
             throw new InvalidPathException('Provided path directory does not exist and/or could not be created');
         }
 
@@ -155,7 +155,7 @@ class FilecacheClient implements CacheInterface
         return serialize($data);
     }
 
-    protected function unserialize($data, $options = null)
+    protected function unserialize($data, array $options = [])
     {
         return unserialize($data, $options);
     }

--- a/src/Client/FilecacheClient.php
+++ b/src/Client/FilecacheClient.php
@@ -51,7 +51,7 @@ class FilecacheClient implements CacheInterface
      */
     public function get($key, $default = null)
     {
-        if (empty($key) || !$this->isSafe()) {
+        if (empty($key)) {
             return $default;
         }
 
@@ -90,6 +90,10 @@ class FilecacheClient implements CacheInterface
      */
     public function set($key, $value, $ttl = null)
     {
+        if (empty($key)) {
+            return false;
+        }
+
         $file = array(
             'key'   => $key,
             'value' => $this->serialize($value),
@@ -97,11 +101,7 @@ class FilecacheClient implements CacheInterface
             'ctime' => time(),
         );
 
-        if ($this->isSafe() && !empty($key)) {
-            return (bool) file_put_contents($this->getFilename($key), json_encode($file));
-        }
-
-        return false;
+        return (bool)file_put_contents($this->getFilename($key), json_encode($file));
     }
 
     /**

--- a/src/Client/FilecacheClient.php
+++ b/src/Client/FilecacheClient.php
@@ -78,7 +78,7 @@ class FilecacheClient implements CacheInterface
 
         $this->incrementAndWriteStatistics(true);
 
-        return unserialize($file['value']) ?? $default;
+        return $this->unserialize($file['value']) ?? $default;
     }
 
     /**
@@ -92,7 +92,7 @@ class FilecacheClient implements CacheInterface
     {
         $file = array(
             'key'   => $key,
-            'value' => serialize($value),
+            'value' => $this->serialize($value),
             'ttl'   => $ttl,
             'ctime' => time(),
         );
@@ -188,5 +188,15 @@ class FilecacheClient implements CacheInterface
         }
 
         return file_exists($this->getFilename($key));
+    }
+
+    protected function serialize($data)
+    {
+        return serialize($data);
+    }
+
+    protected function unserialize($data, ?$options = null)
+    {
+        return unserialize($data, $options);
     }
 }

--- a/src/Client/FilecacheClient.php
+++ b/src/Client/FilecacheClient.php
@@ -7,11 +7,6 @@ use Psr\SimpleCache\CacheInterface;
 
 /**
  * Uses the filesystem to store and retrieve cache entries
- *
- * @package
- * @version $id$
- * @author Kevin Boyd <beryllium@beryllium.ca>
- * @license See LICENSE.md
  */
 class FilecacheClient implements CacheInterface
 {
@@ -111,6 +106,8 @@ class FilecacheClient implements CacheInterface
     }
 
     /**
+     * Build a full path for the provided key
+     *
      * @param string $key
      * @return string
      */

--- a/src/Client/MemcachedClient.php
+++ b/src/Client/MemcachedClient.php
@@ -34,17 +34,21 @@ class MemcachedClient implements CacheInterface
     protected $memcache;
 
     protected $safe    = false;
-    protected $servers = [];
+    /** @var ServerVerifierInterface|null */
+    protected $serverVerifier;
 
     /**
      * Constructs the cache client using an injected Memcache instance
      *
      * @access public
+     *
+     * @param \Memcached|null              $memcache
+     * @param ServerVerifierInterface|null $serverVerifier
      */
-    public function __construct(\Memcached $memcache = null, ServerVerifierInterface $serverVerifier = null)
+    public function __construct(?\Memcached $memcache = null, ?ServerVerifierInterface $serverVerifier = null)
     {
         $this->memcache       = $memcache ?: new \Memcached();
-        $this->serverVerifier = $serverVerifier ?: new MemcacheServerVerifier();
+        $this->serverVerifier = $serverVerifier;
     }
 
     /**
@@ -124,7 +128,7 @@ class MemcachedClient implements CacheInterface
      */
     public function addServer($ip = '127.0.0.1', $port = 11211)
     {
-        if (!$this->serverVerifier->verify($ip, $port)) {
+        if ($this->serverVerifier && !$this->serverVerifier->verify($ip, $port)) {
             return false;
         }
 

--- a/src/Client/MemcachedClient.php
+++ b/src/Client/MemcachedClient.php
@@ -18,12 +18,6 @@ use Psr\SimpleCache\CacheInterface;
  *
  * If the expiration value is 0 (the default), the item never expires (although it may be deleted from the server to
  * make place for other items).
- *
- * @uses    CacheInterface
- * @package
- * @version $id$
- * @author  Kevin Boyd <beryllium@beryllium.ca>
- * @license See LICENSE.md
  */
 class MemcachedClient implements CacheInterface
 {

--- a/src/Client/MemcachedClient.php
+++ b/src/Client/MemcachedClient.php
@@ -2,7 +2,6 @@
 
 namespace Beryllium\Cache\Client;
 
-use Beryllium\Cache\Client\ServerVerifier\MemcacheServerVerifier;
 use Beryllium\Cache\Client\ServerVerifier\ServerVerifierInterface;
 use Psr\SimpleCache\CacheInterface;
 

--- a/src/Client/MemcachedClient.php
+++ b/src/Client/MemcachedClient.php
@@ -33,7 +33,6 @@ class MemcachedClient implements CacheInterface
     /** @var \Memcached|null Memcached instance */
     protected $memcache;
 
-    protected $safe    = false;
     /** @var ServerVerifierInterface|null */
     protected $serverVerifier;
 
@@ -61,10 +60,6 @@ class MemcachedClient implements CacheInterface
      */
     public function get($key, $default = null)
     {
-        if (!$this->safe) {
-            return $default;
-        }
-
         $result = $this->memcache->get($key);
 
         if (!$result && \Memcached::RES_NOTFOUND === $this->memcache->getResultCode()) {
@@ -85,11 +80,7 @@ class MemcachedClient implements CacheInterface
      */
     public function set($key, $value, $ttl = null)
     {
-        if ($this->safe) {
-            return $this->memcache->set($key, $value, $ttl);
-        }
-
-        return false;
+        return $this->memcache->set($key, $value, $ttl);
     }
 
     /**
@@ -101,11 +92,7 @@ class MemcachedClient implements CacheInterface
      */
     public function delete($key)
     {
-        if ($this->safe) {
-            return $this->memcache->delete($key);
-        }
-
-        return false;
+        return $this->memcache->delete($key);
     }
 
     /**
@@ -132,11 +119,7 @@ class MemcachedClient implements CacheInterface
             return false;
         }
 
-        if ($status = $this->memcache->addServer($ip, $port)) {
-            $this->safe = true;
-        }
-
-        return $status;
+        return $this->memcache->addServer($ip, $port);
     }
 
     /**

--- a/src/Exception/InvalidPathException.php
+++ b/src/Exception/InvalidPathException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Beryllium\Cache\Exception;
+
+use Psr\SimpleCache\CacheException;
+
+class InvalidPathException extends \RuntimeException implements CacheException
+{
+}

--- a/tests/Client/ApcuClientTest.php
+++ b/tests/Client/ApcuClientTest.php
@@ -9,6 +9,10 @@ class ApcuClientTest extends TestCase
 {
     public function testInstantiation(): void
     {
+        $enabled = ini_get('apc.enable_cli');
+        $this->assertSame('1', $enabled, 'Forgot to enable apc.enable_cli flag');
+
+        apcu_clear_cache();
         $key    = 'pid-' . getmypid();
         $client = new ApcuClient();
         $this->assertInstanceOf(ApcuClient::class, $client);

--- a/tests/Client/FilecacheClientTest.php
+++ b/tests/Client/FilecacheClientTest.php
@@ -3,6 +3,7 @@
 namespace Beryllium\Cache\Tests\Client;
 
 use Beryllium\Cache\Client\FilecacheClient;
+use Beryllium\Cache\Exception\InvalidPathException;
 use Beryllium\Cache\Statistics\Manager\FilecacheStatisticsManager;
 use Beryllium\Cache\Statistics\Tracker\FilecacheStatisticsTracker;
 use org\bovigo\vfs\vfsStream;
@@ -27,11 +28,12 @@ class FilecacheClientTest extends TestCase
         $this->cache = new FilecacheClient(vfsStream::url('cacheDir'));
     }
 
-    public function testFilecacheConstruct()
+    public function testFilecacheConstructNonexistentPath()
     {
-        $this->assertTrue($this->cache->isSafe());
+        $this->expectException(InvalidPathException::class);
+        $this->expectExceptionMessage('Provided path directory does not exist and/or could not be created');
 
-        // @todo Test failure scenarios
+        new FilecacheClient('/tmp/this/folder/does/not/exist');
     }
 
     public function testSetAndGet()

--- a/tests/Client/MemcachedClientTest.php
+++ b/tests/Client/MemcachedClientTest.php
@@ -34,22 +34,6 @@ class MemcachedClientTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testUnsafeSetReturnsFalse()
-    {
-        $client = new MemcachedClient($this->memcache);
-        $result = $client->set('test-key', 'test-value', 555);
-
-        $this->assertFalse($result);
-    }
-
-    public function testUnsafeDeleteReturnsFalse()
-    {
-        $client = new MemcachedClient($this->memcache);
-        $result = $client->delete('test-key');
-
-        $this->assertFalse($result);
-    }
-
     public function testAddServerCallsVerifier()
     {
         $ip = '127.0.0.1';


### PR DESCRIPTION
It seems that the `$this->safe` mechanism from v1 may not be necessary in v2. This PR will remove it from the various clients that may or may not still implement it.

In the future, if some mechanism is needed to suppress exceptions/errors, it should take the form of a decorator encapsulation that "eats" the error conditions.

This PR also makes the `serverVerifier` parameter of `MemcachedClient` fully optional, so that server verification is not performed if the verifier is not injected in the constructor. This should remove a potential speedbump/timeout.